### PR TITLE
Fixed #7 -- Stop rotation after one cycle

### DIFF
--- a/app/src/main/java/com/sdsmdg/harjot/rotatingtextlibrary/MainActivity.java
+++ b/app/src/main/java/com/sdsmdg/harjot/rotatingtextlibrary/MainActivity.java
@@ -5,6 +5,7 @@ import android.graphics.Typeface;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.text.TextUtils;
+import android.util.Log;
 import android.view.View;
 import android.view.animation.AccelerateInterpolator;
 import android.view.animation.DecelerateInterpolator;
@@ -12,7 +13,10 @@ import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.Spinner;
+import android.widget.TextView;
+import android.widget.Toast;
 
+import com.sdsmdg.harjot.rotatingtext.RotatingTextSwitcher;
 import com.sdsmdg.harjot.rotatingtext.RotatingTextWrapper;
 import com.sdsmdg.harjot.rotatingtext.models.Rotatable;
 
@@ -22,10 +26,14 @@ import java.util.List;
 public class MainActivity extends AppCompatActivity {
 
     RotatingTextWrapper rotatingTextWrapper;
+    RotatingTextSwitcher rotatingTextSwitcher;
     Rotatable rotatable, rotatable2;
     Spinner s1;
+    int nCycles;
+    EditText enterCycles;
     EditText e1;
-
+    int n = 0;
+    String etValue;
     Button button;
 
     @Override
@@ -33,6 +41,7 @@ public class MainActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
+        rotatingTextSwitcher = new RotatingTextSwitcher(this);
         Typeface typeface = Typeface.createFromAsset(getAssets(), "fonts/Raleway-Light.ttf");
         Typeface typeface2 = Typeface.createFromAsset(getAssets(), "fonts/Reckoner_Bold.ttf");
 
@@ -41,26 +50,32 @@ public class MainActivity extends AppCompatActivity {
         rotatingTextWrapper.setTypeface(typeface2);
 
 //        rotatable = new Rotatable(Color.parseColor("#FFA036"), 1000, "Word00", "Word01", "Word02");
-        rotatable = new Rotatable(Color.parseColor("#FFA036"), 1000, "rotating", "text", "library");
-        rotatable.setSize(25);
-        rotatable.setTypeface(typeface);
-        rotatable.setInterpolator(new AccelerateInterpolator());
-        rotatable.setAnimationDuration(500);
-
         rotatable2 = new Rotatable(Color.parseColor("#123456"), 1000, "word", "word01", "word02");
         rotatable2.setSize(25);
         rotatable2.setTypeface(typeface);
         rotatable2.setInterpolator(new DecelerateInterpolator());
         rotatable2.setAnimationDuration(500);
 
+
+        rotatable = new Rotatable(Color.parseColor("#FFA036"), 1000, "rotating", "text", "library");
+        rotatable.setSize(25);
+        rotatable.setTypeface(typeface);
+        rotatable.setInterpolator(new AccelerateInterpolator());
+        rotatable.setAnimationDuration(500);
+
+
         rotatingTextWrapper.setContent("?abc ? abc", rotatable, rotatable2);
 //        rotatingTextWrapper.setContent("? abc", rotatable);
 
         s1 = (Spinner) findViewById(R.id.spinner);
+
+
+
         List<Integer> list = new ArrayList<Integer>();
         list.add(1);
         list.add(2);
         list.add(3);
+
         ArrayAdapter<Integer> dataAdapter = new ArrayAdapter<Integer>(this,
                 android.R.layout.simple_spinner_item, list);
         dataAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
@@ -80,6 +95,25 @@ public class MainActivity extends AppCompatActivity {
                 }
             }
         });
+
+        Button button2 = findViewById(R.id.set_button);
+        button2.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                enterCycles = (EditText) findViewById(R.id.enterCycles);
+
+
+                if(!enterCycles.getText().toString().equals("") && enterCycles.getText() != null) {
+                    nCycles = Integer.parseInt(enterCycles.getText().toString());
+                }
+
+                rotatingTextSwitcher.cycles(nCycles);
+
+                if (rotatingTextWrapper.getSwitcherList().get(0).isPaused()) {
+                    rotatingTextWrapper.resume(0);
+                }
+            }
+        });
     }
 
     public void replaceWord(View view) {
@@ -90,5 +124,7 @@ public class MainActivity extends AppCompatActivity {
             rotatingTextWrapper.setAdaptable(true);
             rotatingTextWrapper.addWord(0, (int) s1.getSelectedItem() - 1, newWord);
         }
+
     }
 }
+

--- a/app/src/main/java/com/sdsmdg/harjot/rotatingtextlibrary/MainActivity.java
+++ b/app/src/main/java/com/sdsmdg/harjot/rotatingtextlibrary/MainActivity.java
@@ -31,6 +31,7 @@ public class MainActivity extends AppCompatActivity {
     int nCycles;
     EditText enterCycles;
     EditText e1;
+
     Button button;
 
     @Override

--- a/app/src/main/java/com/sdsmdg/harjot/rotatingtextlibrary/MainActivity.java
+++ b/app/src/main/java/com/sdsmdg/harjot/rotatingtextlibrary/MainActivity.java
@@ -5,7 +5,7 @@ import android.graphics.Typeface;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.text.TextUtils;
-import android.util.Log;
+
 import android.view.View;
 import android.view.animation.AccelerateInterpolator;
 import android.view.animation.DecelerateInterpolator;
@@ -13,8 +13,6 @@ import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.Spinner;
-import android.widget.TextView;
-import android.widget.Toast;
 
 import com.sdsmdg.harjot.rotatingtext.RotatingTextSwitcher;
 import com.sdsmdg.harjot.rotatingtext.RotatingTextWrapper;
@@ -107,7 +105,8 @@ public class MainActivity extends AppCompatActivity {
                     nCycles = Integer.parseInt(enterCycles.getText().toString());
                 }
 
-                rotatingTextSwitcher.cycles(nCycles,word);
+                rotatable.setInitialWord(word);
+                rotatable.setCycles(nCycles);
 
                 if (rotatingTextWrapper.getSwitcherList().get(0).isPaused()) {
                     rotatingTextWrapper.resume(0);

--- a/app/src/main/java/com/sdsmdg/harjot/rotatingtextlibrary/MainActivity.java
+++ b/app/src/main/java/com/sdsmdg/harjot/rotatingtextlibrary/MainActivity.java
@@ -29,11 +29,10 @@ public class MainActivity extends AppCompatActivity {
     RotatingTextSwitcher rotatingTextSwitcher;
     Rotatable rotatable, rotatable2;
     Spinner s1;
+    String word;
     int nCycles;
     EditText enterCycles;
     EditText e1;
-    int n = 0;
-    String etValue;
     Button button;
 
     @Override
@@ -63,6 +62,7 @@ public class MainActivity extends AppCompatActivity {
         rotatable.setInterpolator(new AccelerateInterpolator());
         rotatable.setAnimationDuration(500);
 
+        word = rotatable.getTextAt(0);
 
         rotatingTextWrapper.setContent("?abc ? abc", rotatable, rotatable2);
 //        rotatingTextWrapper.setContent("? abc", rotatable);
@@ -107,7 +107,7 @@ public class MainActivity extends AppCompatActivity {
                     nCycles = Integer.parseInt(enterCycles.getText().toString());
                 }
 
-                rotatingTextSwitcher.cycles(nCycles);
+                rotatingTextSwitcher.cycles(nCycles,word);
 
                 if (rotatingTextWrapper.getSwitcherList().get(0).isPaused()) {
                     rotatingTextWrapper.resume(0);

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -60,11 +60,11 @@
 
         <EditText
             android:id="@+id/enterCycles"
-            android:layout_width="90dp"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginLeft="24dp"
-            android:textSize="10sp"
-            android:layout_marginRight="24dp"
+            android:layout_marginLeft="10dp"
+            android:textSize="15sp"
+            android:layout_marginRight="10dp"
 
 
             android:layout_alignParentBottom="true"
@@ -74,7 +74,8 @@
             android:layout_toRightOf="@id/pause_button"
             android:layout_toLeftOf="@id/set_button"
             android:inputType="number"
-            android:layout_toEndOf="@id/pause_button" />
+            android:layout_toEndOf="@id/pause_button"
+            android:layout_toStartOf="@id/set_button" />
 
         <Button
             android:id="@+id/set_button"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -34,6 +34,7 @@
             android:padding="5dp">
 
         </Spinner>
+
     </LinearLayout>
 
     <Button
@@ -44,12 +45,46 @@
         android:onClick="replaceWord"
         android:text="replace" />
 
-    <Button
-        android:id="@+id/pause_button"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignParentBottom="true"
-        android:layout_centerHorizontal="true"
-        android:text="Pause/Resume" />
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_alignParentBottom="true">
+
+        <Button
+            android:id="@+id/pause_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentBottom="true"
+            android:text="pause/resume" />
+
+
+        <EditText
+            android:id="@+id/enterCycles"
+            android:layout_width="90dp"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="24dp"
+            android:textSize="10sp"
+            android:layout_marginRight="24dp"
+
+
+            android:layout_alignParentBottom="true"
+
+            android:hint="No. of cycles"
+            android:ems="10"
+            android:layout_toRightOf="@id/pause_button"
+            android:layout_toLeftOf="@id/set_button"
+            android:inputType="number"
+            android:layout_toEndOf="@id/pause_button" />
+
+        <Button
+            android:id="@+id/set_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Set"
+            android:layout_alignParentBottom="true"
+            android:layout_alignParentRight="true"
+            />
+    </RelativeLayout>
+
 
 </RelativeLayout>

--- a/rotatingtext/src/main/java/com/sdsmdg/harjot/rotatingtext/RotatingTextSwitcher.java
+++ b/rotatingtext/src/main/java/com/sdsmdg/harjot/rotatingtext/RotatingTextSwitcher.java
@@ -9,12 +9,13 @@ import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.graphics.Path;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import com.sdsmdg.harjot.rotatingtext.models.Rotatable;
+
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.TimeUnit;
+
 import io.reactivex.Observable;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.Disposable;
@@ -153,10 +154,7 @@ public class RotatingTextSwitcher extends TextView {
 
                 canvas.drawTextOnPath(oldText, rotatable.getPathOut(), 0.0f, 0.0f, paint);
             }
-
         }
-
-
     }
 
     private void animateInHorizontal() {
@@ -181,7 +179,6 @@ public class RotatingTextSwitcher extends TextView {
         animator.setInterpolator(rotatable.getInterpolator());
         animator.setDuration(rotatable.getAnimationDuration());
         animator.start();
-
     }
 
     private void animateOutHorizontal() {
@@ -198,7 +195,6 @@ public class RotatingTextSwitcher extends TextView {
         animator.setInterpolator(rotatable.getInterpolator());
         animator.setDuration(rotatable.getAnimationDuration());
         animator.start();
-
     }
 
     private void animateInCurve() {
@@ -276,13 +272,9 @@ public class RotatingTextSwitcher extends TextView {
         animator.start();
     }
 
-    public void pause() {
-        isPaused = true;
-    }
+    public void pause() { isPaused = true; }
 
-    public void resume() {
-        isPaused = false;
-    }
+    public void resume() { isPaused = false; }
 
     private void pauseRender() {
         if (disposable != null && !disposable.isDisposed()) {
@@ -358,9 +350,7 @@ public class RotatingTextSwitcher extends TextView {
 
     }
 
-    public boolean isPaused() {
-        return isPaused;
-    }
+    public boolean isPaused() { return isPaused; }
 
 }
 

--- a/rotatingtext/src/main/java/com/sdsmdg/harjot/rotatingtext/RotatingTextSwitcher.java
+++ b/rotatingtext/src/main/java/com/sdsmdg/harjot/rotatingtext/RotatingTextSwitcher.java
@@ -8,9 +8,14 @@ import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.graphics.Path;
+import android.text.Layout;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import com.sdsmdg.harjot.rotatingtext.models.Rotatable;
+//import com.sdsmdg.harjot.AndroidStudioProjects.RotatingText.rotatingtextlibrary;
+
+import org.w3c.dom.Text;
 
 import java.util.Timer;
 import java.util.TimerTask;
@@ -32,12 +37,13 @@ public class RotatingTextSwitcher extends TextView {
     private Rotatable rotatable;
 
     private Paint paint;
-
+    static int n = 0,val = 0;
     private float density;
 
     private boolean isRotatableSet = false;
 
     private Path pathIn, pathOut;
+
 
     private Timer updateWordTimer;
 
@@ -123,7 +129,11 @@ public class RotatingTextSwitcher extends TextView {
                 ((Activity) context).runOnUiThread(new Runnable() {
                     @Override
                     public void run() {
-                        if (isPaused) {
+                        if(isPaused && val == 0){
+                            pauseRender();
+                        }
+                        else if (isPaused && n == val+1) {
+                            // Toast.makeText(context, "g", Toast.LENGTH_SHORT).show();
                             pauseRender();
                         } else {
                             animationInterface.setAnimationRunning(true);
@@ -141,6 +151,7 @@ public class RotatingTextSwitcher extends TextView {
 
     @Override
     protected void onDraw(Canvas canvas) {
+
         if (isRotatableSet) {
             if (rotatable.isUpdated()) {
                 updatePaint();
@@ -154,8 +165,13 @@ public class RotatingTextSwitcher extends TextView {
 
                 canvas.drawTextOnPath(oldText, rotatable.getPathOut(), 0.0f, 0.0f, paint);
             }
+
+
         }
+
     }
+
+
 
     private void animateInHorizontal() {
         ValueAnimator animator = ValueAnimator.ofFloat(0.0f, getHeight());
@@ -179,6 +195,7 @@ public class RotatingTextSwitcher extends TextView {
         animator.setInterpolator(rotatable.getInterpolator());
         animator.setDuration(rotatable.getAnimationDuration());
         animator.start();
+
     }
 
     private void animateOutHorizontal() {
@@ -195,7 +212,11 @@ public class RotatingTextSwitcher extends TextView {
         animator.setInterpolator(rotatable.getInterpolator());
         animator.setDuration(rotatable.getAnimationDuration());
         animator.start();
+
     }
+
+
+
 
     private void animateInCurve() {
         final int stringLength = rotatable.peekNextWord().length();
@@ -322,16 +343,27 @@ public class RotatingTextSwitcher extends TextView {
                 ((Activity) context).runOnUiThread(new Runnable() {
                     @Override
                     public void run() {
-                        if (isPaused) {
+                        if(isPaused ) {
                             pauseRender();
-                        } else {
-                            oldText = currentText;
-                            currentText = rotatable.getNextWord();
-                            animationInterface.setAnimationRunning(true);
-                            resumeRender();
-                            animateInHorizontal();
-                            animateOutHorizontal();
+                        }
 
+                        else {
+                            if (currentText.equalsIgnoreCase("rotating") && val != 0) {
+                                n = n + 1;
+                                //Toast.makeText(context, currentText + n + "," + val, Toast.LENGTH_SHORT).show();
+                            }
+                            if (n == val+1 && val != 0) {
+                                val = 0;
+                                n = 0;
+                                pauseRender();
+                            } else {
+                                oldText = currentText;
+                                currentText = rotatable.getNextWord();
+                                animationInterface.setAnimationRunning(true);
+                                resumeRender();
+                                animateInHorizontal();
+                                animateOutHorizontal();
+                            }
                         }
                     }
                 });
@@ -343,5 +375,13 @@ public class RotatingTextSwitcher extends TextView {
     public boolean isPaused() {
         return isPaused;
     }
+
+    public void cycles(int val) {
+        this.val = val;
+
+
+    }
+
+
 
 }

--- a/rotatingtext/src/main/java/com/sdsmdg/harjot/rotatingtext/RotatingTextSwitcher.java
+++ b/rotatingtext/src/main/java/com/sdsmdg/harjot/rotatingtext/RotatingTextSwitcher.java
@@ -31,14 +31,11 @@ public class RotatingTextSwitcher extends TextView {
     private Rotatable rotatable;
 
     private Paint paint;
-    static int countCycles=0,nCycles=0;
-
     private float density;
 
     private boolean isRotatableSet = false;
 
     private Path pathIn, pathOut;
-
 
     private Timer updateWordTimer;
 
@@ -46,7 +43,6 @@ public class RotatingTextSwitcher extends TextView {
 
     private String currentText = "";
     private String oldText = "";
-    private static String initialWord;
 
     AnimationInterface animationInterface = new AnimationInterface(false);
 
@@ -62,7 +58,6 @@ public class RotatingTextSwitcher extends TextView {
         isRotatableSet = true;
         init();
     }
-
 
     private void init() {
         paint = getPaint();
@@ -100,7 +95,6 @@ public class RotatingTextSwitcher extends TextView {
 
                 rotatable.setPathOut(pathOut);
 
-
             }
         });
 
@@ -129,7 +123,7 @@ public class RotatingTextSwitcher extends TextView {
                         if(isPaused) {
                             pauseRender();
                         }
-                       else {
+                        else {
                             animationInterface.setAnimationRunning(true);
                             resumeRender();
                             animateInHorizontal();
@@ -160,8 +154,8 @@ public class RotatingTextSwitcher extends TextView {
                 canvas.drawTextOnPath(oldText, rotatable.getPathOut(), 0.0f, 0.0f, paint);
             }
 
-
         }
+
 
     }
 
@@ -206,7 +200,7 @@ public class RotatingTextSwitcher extends TextView {
         animator.start();
 
     }
-    
+
     private void animateInCurve() {
         final int stringLength = rotatable.peekNextWord().length();
 //        long perCharacterAnimDuration = rotatable.getAnimationDuration() / stringLength;
@@ -338,19 +332,17 @@ public class RotatingTextSwitcher extends TextView {
 
                         else {
 
-                            if (currentText.equals(initialWord) && nCycles != 0) {
-                                countCycles = countCycles + 1;
+                            if (currentText.equals(rotatable.getInitialWord()) && rotatable.getCycles() != 0) {
+                                rotatable.countCycles(true);
                             }
 
-                            if (countCycles >= nCycles+1 && nCycles != 0) {
-                                nCycles = 0;
-                                countCycles = 0;
+                            if (rotatable.countCycles(false) >= rotatable.getCycles()+1 && rotatable.getCycles() != 0) {
+                                rotatable.setCycles(0);
                                 isPaused = true;
                                 pauseRender();
                             }
 
                             else {
-
                                 oldText = currentText;
                                 currentText = rotatable.getNextWord();
                                 animationInterface.setAnimationRunning(true);
@@ -370,8 +362,11 @@ public class RotatingTextSwitcher extends TextView {
         return isPaused;
     }
 
-    public void cycles(int val,String word) {
-        nCycles = val;
-        initialWord = word;
-    }
 }
+
+
+
+
+
+
+

--- a/rotatingtext/src/main/java/com/sdsmdg/harjot/rotatingtext/RotatingTextSwitcher.java
+++ b/rotatingtext/src/main/java/com/sdsmdg/harjot/rotatingtext/RotatingTextSwitcher.java
@@ -28,13 +28,13 @@ import io.reactivex.schedulers.Schedulers;
 public class RotatingTextSwitcher extends TextView {
 
     private Context context;
-    private Rotatable rotatable,rotatable2;
+    private Rotatable rotatable;
 
     private Paint paint;
     static int n=0,val=0;
 
     private float density;
-    RotatingTextWrapper rotatingTextWrapper;
+
     private boolean isRotatableSet = false;
 
     private Path pathIn, pathOut;

--- a/rotatingtext/src/main/java/com/sdsmdg/harjot/rotatingtext/RotatingTextSwitcher.java
+++ b/rotatingtext/src/main/java/com/sdsmdg/harjot/rotatingtext/RotatingTextSwitcher.java
@@ -32,6 +32,7 @@ public class RotatingTextSwitcher extends TextView {
     private Rotatable rotatable;
 
     private Paint paint;
+
     private float density;
 
     private boolean isRotatableSet = false;
@@ -140,7 +141,6 @@ public class RotatingTextSwitcher extends TextView {
 
     @Override
     protected void onDraw(Canvas canvas) {
-
         if (isRotatableSet) {
             if (rotatable.isUpdated()) {
                 updatePaint();
@@ -272,9 +272,13 @@ public class RotatingTextSwitcher extends TextView {
         animator.start();
     }
 
-    public void pause() { isPaused = true; }
+    public void pause() {
+        isPaused = true;
+    }
 
-    public void resume() { isPaused = false; }
+    public void resume() {
+        isPaused = false;
+    }
 
     private void pauseRender() {
         if (disposable != null && !disposable.isDisposed()) {

--- a/rotatingtext/src/main/java/com/sdsmdg/harjot/rotatingtext/RotatingTextSwitcher.java
+++ b/rotatingtext/src/main/java/com/sdsmdg/harjot/rotatingtext/RotatingTextSwitcher.java
@@ -353,10 +353,3 @@ public class RotatingTextSwitcher extends TextView {
     public boolean isPaused() { return isPaused; }
 
 }
-
-
-
-
-
-
-

--- a/rotatingtext/src/main/java/com/sdsmdg/harjot/rotatingtext/RotatingTextSwitcher.java
+++ b/rotatingtext/src/main/java/com/sdsmdg/harjot/rotatingtext/RotatingTextSwitcher.java
@@ -9,6 +9,8 @@ import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.graphics.Path;
 import android.widget.TextView;
+import android.widget.Toast;
+
 import com.sdsmdg.harjot.rotatingtext.models.Rotatable;
 import java.util.Timer;
 import java.util.TimerTask;
@@ -26,12 +28,13 @@ import io.reactivex.schedulers.Schedulers;
 public class RotatingTextSwitcher extends TextView {
 
     private Context context;
-    private Rotatable rotatable;
+    private Rotatable rotatable,rotatable2;
 
     private Paint paint;
-    static int n = 0,val = 0;
-    private float density;
+    static int n=0,val=0;
 
+    private float density;
+    RotatingTextWrapper rotatingTextWrapper;
     private boolean isRotatableSet = false;
 
     private Path pathIn, pathOut;
@@ -43,6 +46,7 @@ public class RotatingTextSwitcher extends TextView {
 
     private String currentText = "";
     private String oldText = "";
+    private static String initialWord;
 
     AnimationInterface animationInterface = new AnimationInterface(false);
 
@@ -58,6 +62,7 @@ public class RotatingTextSwitcher extends TextView {
         isRotatableSet = true;
         init();
     }
+
 
     private void init() {
         paint = getPaint();
@@ -121,13 +126,10 @@ public class RotatingTextSwitcher extends TextView {
                 ((Activity) context).runOnUiThread(new Runnable() {
                     @Override
                     public void run() {
-                        if(isPaused && val == 0){
+                        if(isPaused) {
                             pauseRender();
                         }
-                        else if (n == val+1) {
-                           isPaused = true;
-                            pauseRender();
-                        } else {
+                       else {
                             animationInterface.setAnimationRunning(true);
                             resumeRender();
                             animateInHorizontal();
@@ -162,8 +164,6 @@ public class RotatingTextSwitcher extends TextView {
         }
 
     }
-
-
 
     private void animateInHorizontal() {
         ValueAnimator animator = ValueAnimator.ofFloat(0.0f, getHeight());
@@ -337,15 +337,20 @@ public class RotatingTextSwitcher extends TextView {
                         }
 
                         else {
-                            if (currentText.equalsIgnoreCase("rotating") && val != 0) {
+
+                            if (currentText.equals(initialWord) && val != 0) {
                                 n = n + 1;
                             }
-                            if (n == val+1 && val != 0) {
+
+                            if (n >= val+1 && val != 0) {
                                 val = 0;
                                 n = 0;
                                 isPaused = true;
                                 pauseRender();
-                            } else {
+                            }
+
+                            else {
+
                                 oldText = currentText;
                                 currentText = rotatable.getNextWord();
                                 animationInterface.setAnimationRunning(true);
@@ -365,7 +370,8 @@ public class RotatingTextSwitcher extends TextView {
         return isPaused;
     }
 
-    public void cycles(int val) {
+    public void cycles(int val,String word) {
         this.val = val;
+        initialWord = word;
     }
 }

--- a/rotatingtext/src/main/java/com/sdsmdg/harjot/rotatingtext/RotatingTextSwitcher.java
+++ b/rotatingtext/src/main/java/com/sdsmdg/harjot/rotatingtext/RotatingTextSwitcher.java
@@ -124,8 +124,8 @@ public class RotatingTextSwitcher extends TextView {
                         if(isPaused && val == 0){
                             pauseRender();
                         }
-                        else if (isPaused && n == val+1) {
-                            // Toast.makeText(context, "g", Toast.LENGTH_SHORT).show();
+                        else if (n == val+1) {
+                           isPaused = true;
                             pauseRender();
                         } else {
                             animationInterface.setAnimationRunning(true);
@@ -206,7 +206,7 @@ public class RotatingTextSwitcher extends TextView {
         animator.start();
 
     }
-
+    
     private void animateInCurve() {
         final int stringLength = rotatable.peekNextWord().length();
 //        long perCharacterAnimDuration = rotatable.getAnimationDuration() / stringLength;
@@ -343,6 +343,7 @@ public class RotatingTextSwitcher extends TextView {
                             if (n == val+1 && val != 0) {
                                 val = 0;
                                 n = 0;
+                                isPaused = true;
                                 pauseRender();
                             } else {
                                 oldText = currentText;

--- a/rotatingtext/src/main/java/com/sdsmdg/harjot/rotatingtext/RotatingTextSwitcher.java
+++ b/rotatingtext/src/main/java/com/sdsmdg/harjot/rotatingtext/RotatingTextSwitcher.java
@@ -97,6 +97,7 @@ public class RotatingTextSwitcher extends TextView {
 
                 rotatable.setPathOut(pathOut);
 
+
             }
         });
 
@@ -122,7 +123,7 @@ public class RotatingTextSwitcher extends TextView {
                 ((Activity) context).runOnUiThread(new Runnable() {
                     @Override
                     public void run() {
-                        if(isPaused) {
+                        if (isPaused) {
                             pauseRender();
                         }
                         else {
@@ -322,7 +323,7 @@ public class RotatingTextSwitcher extends TextView {
                 ((Activity) context).runOnUiThread(new Runnable() {
                     @Override
                     public void run() {
-                        if(isPaused ) {
+                        if (isPaused) {
                             pauseRender();
                         }
 

--- a/rotatingtext/src/main/java/com/sdsmdg/harjot/rotatingtext/RotatingTextSwitcher.java
+++ b/rotatingtext/src/main/java/com/sdsmdg/harjot/rotatingtext/RotatingTextSwitcher.java
@@ -354,6 +354,8 @@ public class RotatingTextSwitcher extends TextView {
 
     }
 
-    public boolean isPaused() { return isPaused; }
+    public boolean isPaused() {
+        return isPaused;
+    }
 
 }

--- a/rotatingtext/src/main/java/com/sdsmdg/harjot/rotatingtext/RotatingTextSwitcher.java
+++ b/rotatingtext/src/main/java/com/sdsmdg/harjot/rotatingtext/RotatingTextSwitcher.java
@@ -31,7 +31,7 @@ public class RotatingTextSwitcher extends TextView {
     private Rotatable rotatable;
 
     private Paint paint;
-    static int n=0,val=0;
+    static int countCycles=0,nCycles=0;
 
     private float density;
 
@@ -338,13 +338,13 @@ public class RotatingTextSwitcher extends TextView {
 
                         else {
 
-                            if (currentText.equals(initialWord) && val != 0) {
-                                n = n + 1;
+                            if (currentText.equals(initialWord) && nCycles != 0) {
+                                countCycles = countCycles + 1;
                             }
 
-                            if (n >= val+1 && val != 0) {
-                                val = 0;
-                                n = 0;
+                            if (countCycles >= nCycles+1 && nCycles != 0) {
+                                nCycles = 0;
+                                countCycles = 0;
                                 isPaused = true;
                                 pauseRender();
                             }
@@ -371,7 +371,7 @@ public class RotatingTextSwitcher extends TextView {
     }
 
     public void cycles(int val,String word) {
-        this.val = val;
+        nCycles = val;
         initialWord = word;
     }
 }

--- a/rotatingtext/src/main/java/com/sdsmdg/harjot/rotatingtext/RotatingTextSwitcher.java
+++ b/rotatingtext/src/main/java/com/sdsmdg/harjot/rotatingtext/RotatingTextSwitcher.java
@@ -8,19 +8,11 @@ import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.graphics.Path;
-import android.text.Layout;
 import android.widget.TextView;
-import android.widget.Toast;
-
 import com.sdsmdg.harjot.rotatingtext.models.Rotatable;
-//import com.sdsmdg.harjot.AndroidStudioProjects.RotatingText.rotatingtextlibrary;
-
-import org.w3c.dom.Text;
-
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.TimeUnit;
-
 import io.reactivex.Observable;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.Disposable;
@@ -215,9 +207,6 @@ public class RotatingTextSwitcher extends TextView {
 
     }
 
-
-
-
     private void animateInCurve() {
         final int stringLength = rotatable.peekNextWord().length();
 //        long perCharacterAnimDuration = rotatable.getAnimationDuration() / stringLength;
@@ -350,7 +339,6 @@ public class RotatingTextSwitcher extends TextView {
                         else {
                             if (currentText.equalsIgnoreCase("rotating") && val != 0) {
                                 n = n + 1;
-                                //Toast.makeText(context, currentText + n + "," + val, Toast.LENGTH_SHORT).show();
                             }
                             if (n == val+1 && val != 0) {
                                 val = 0;
@@ -378,10 +366,5 @@ public class RotatingTextSwitcher extends TextView {
 
     public void cycles(int val) {
         this.val = val;
-
-
     }
-
-
-
 }

--- a/rotatingtext/src/main/java/com/sdsmdg/harjot/rotatingtext/RotatingTextWrapper.java
+++ b/rotatingtext/src/main/java/com/sdsmdg/harjot/rotatingtext/RotatingTextWrapper.java
@@ -1,24 +1,24 @@
 package com.sdsmdg.harjot.rotatingtext;
 
-        import android.content.Context;
-        import android.graphics.Color;
-        import android.graphics.Paint;
-        import android.graphics.Rect;
-        import android.graphics.Typeface;
-        import android.os.Build;
-        import android.text.TextUtils;
-        import android.util.AttributeSet;
-        import android.util.TypedValue;
-        import android.view.View;
-        import android.widget.RelativeLayout;
-        import android.widget.TextView;
+import android.content.Context;
+import android.graphics.Color;
+import android.graphics.Paint;
+import android.graphics.Rect;
+import android.graphics.Typeface;
+import android.os.Build;
+import android.text.TextUtils;
+import android.util.AttributeSet;
+import android.util.TypedValue;
+import android.view.View;
+import android.widget.RelativeLayout;
+import android.widget.TextView;
 
-        import com.sdsmdg.harjot.rotatingtext.models.Rotatable;
-        import com.sdsmdg.harjot.rotatingtext.utils.Utils;
+import com.sdsmdg.harjot.rotatingtext.models.Rotatable;
+import com.sdsmdg.harjot.rotatingtext.utils.Utils;
 
-        import java.util.ArrayList;
-        import java.util.Collections;
-        import java.util.List;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Created by Harjot on 01-May-17.

--- a/rotatingtext/src/main/java/com/sdsmdg/harjot/rotatingtext/RotatingTextWrapper.java
+++ b/rotatingtext/src/main/java/com/sdsmdg/harjot/rotatingtext/RotatingTextWrapper.java
@@ -370,19 +370,35 @@ public class RotatingTextWrapper extends RelativeLayout {
         }
     }
 
-    public void setAdaptable(boolean adaptable) { this.adaptable = adaptable; }
+    public void setAdaptable(boolean adaptable) {
+        this.adaptable = adaptable;
+    }
 
-    public Typeface getTypeface() { return typeface; }
+    public Typeface getTypeface() {
+        return typeface;
+    }
 
-    public void setTypeface(Typeface typeface) { this.typeface = typeface; }
+    public void setTypeface(Typeface typeface) {
+        this.typeface = typeface;
+    }
 
-    public int getSize() { return size; }
+    public int getSize() {
+        return size;
+    }
 
-    public void setSize(int size) { this.size = size; }
+    public void setSize(int size) {
+        this.size = size;
+    }
 
-    public void pause(int position) { switcherList.get(position).pause(); }
+    public void pause(int position) {
+        switcherList.get(position).pause();
+    }
 
-    public void resume(int position) { switcherList.get(position).resume(); }
+    public void resume(int position) {
+        switcherList.get(position).resume();
+    }
 
-    public List<RotatingTextSwitcher> getSwitcherList() { return switcherList; }
+    public List<RotatingTextSwitcher> getSwitcherList() {
+        return switcherList;
+    }
 }

--- a/rotatingtext/src/main/java/com/sdsmdg/harjot/rotatingtext/RotatingTextWrapper.java
+++ b/rotatingtext/src/main/java/com/sdsmdg/harjot/rotatingtext/RotatingTextWrapper.java
@@ -1,24 +1,24 @@
 package com.sdsmdg.harjot.rotatingtext;
 
-import android.content.Context;
-import android.graphics.Color;
-import android.graphics.Paint;
-import android.graphics.Rect;
-import android.graphics.Typeface;
-import android.os.Build;
-import android.text.TextUtils;
-import android.util.AttributeSet;
-import android.util.TypedValue;
-import android.view.View;
-import android.widget.RelativeLayout;
-import android.widget.TextView;
+        import android.content.Context;
+        import android.graphics.Color;
+        import android.graphics.Paint;
+        import android.graphics.Rect;
+        import android.graphics.Typeface;
+        import android.os.Build;
+        import android.text.TextUtils;
+        import android.util.AttributeSet;
+        import android.util.TypedValue;
+        import android.view.View;
+        import android.widget.RelativeLayout;
+        import android.widget.TextView;
 
-import com.sdsmdg.harjot.rotatingtext.models.Rotatable;
-import com.sdsmdg.harjot.rotatingtext.utils.Utils;
+        import com.sdsmdg.harjot.rotatingtext.models.Rotatable;
+        import com.sdsmdg.harjot.rotatingtext.utils.Utils;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+        import java.util.ArrayList;
+        import java.util.Collections;
+        import java.util.List;
 
 /**
  * Created by Harjot on 01-May-17.
@@ -88,11 +88,9 @@ public class RotatingTextWrapper extends RelativeLayout {
 
             if (array.length == 0) {
                 final RotatingTextSwitcher textSwitcher = new RotatingTextSwitcher(context);
-
                 switcherList.add(textSwitcher);
 
                 textSwitcher.setRotatable(rotatableList.get(0));
-
 
                 if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR1) {
                     textSwitcher.setId(Utils.generateViewId());
@@ -288,6 +286,8 @@ public class RotatingTextWrapper extends RelativeLayout {
             }
         }
     }
+
+
 
 
     private void setChanges(RotatingTextSwitcher switcher, Rotatable toChange) {

--- a/rotatingtext/src/main/java/com/sdsmdg/harjot/rotatingtext/RotatingTextWrapper.java
+++ b/rotatingtext/src/main/java/com/sdsmdg/harjot/rotatingtext/RotatingTextWrapper.java
@@ -287,8 +287,6 @@ public class RotatingTextWrapper extends RelativeLayout {
         }
     }
 
-    
-  
 
     private void setChanges(RotatingTextSwitcher switcher, Rotatable toChange) {
         switcher.setText(toChange.getLargestWordWithSpace());
@@ -298,7 +296,7 @@ public class RotatingTextWrapper extends RelativeLayout {
             else reduceSize(changedSize / getSize());
         }
 
-   
+
     }
 
     private int availablePixels() {
@@ -401,4 +399,7 @@ public class RotatingTextWrapper extends RelativeLayout {
     public List<RotatingTextSwitcher> getSwitcherList() {
         return switcherList;
     }
+
+
+
 }

--- a/rotatingtext/src/main/java/com/sdsmdg/harjot/rotatingtext/RotatingTextWrapper.java
+++ b/rotatingtext/src/main/java/com/sdsmdg/harjot/rotatingtext/RotatingTextWrapper.java
@@ -12,8 +12,10 @@ import android.util.TypedValue;
 import android.view.View;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
+
 import com.sdsmdg.harjot.rotatingtext.models.Rotatable;
 import com.sdsmdg.harjot.rotatingtext.utils.Utils;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -368,36 +370,19 @@ public class RotatingTextWrapper extends RelativeLayout {
         }
     }
 
-    public void setAdaptable(boolean adaptable) {
-        this.adaptable = adaptable;
-    }
+    public void setAdaptable(boolean adaptable) { this.adaptable = adaptable; }
 
-    public Typeface getTypeface() {
-        return typeface;
-    }
+    public Typeface getTypeface() { return typeface; }
 
-    public void setTypeface(Typeface typeface) {
-        this.typeface = typeface;
-    }
+    public void setTypeface(Typeface typeface) { this.typeface = typeface; }
 
-    public int getSize() {
-        return size;
-    }
+    public int getSize() { return size; }
 
-    public void setSize(int size) {
-        this.size = size;
-    }
+    public void setSize(int size) { this.size = size; }
 
-    public void pause(int position) {
-        switcherList.get(position).pause();
-    }
+    public void pause(int position) { switcherList.get(position).pause(); }
 
-    public void resume(int position) {
-        switcherList.get(position).resume();
-    }
+    public void resume(int position) { switcherList.get(position).resume(); }
 
-    public List<RotatingTextSwitcher> getSwitcherList() {
-        return switcherList;
-    }
-
+    public List<RotatingTextSwitcher> getSwitcherList() { return switcherList; }
 }

--- a/rotatingtext/src/main/java/com/sdsmdg/harjot/rotatingtext/RotatingTextWrapper.java
+++ b/rotatingtext/src/main/java/com/sdsmdg/harjot/rotatingtext/RotatingTextWrapper.java
@@ -400,5 +400,4 @@ public class RotatingTextWrapper extends RelativeLayout {
         return switcherList;
     }
 
-    public Rotatable getRotatable() { return (rotatableList.get(0)); }
 }

--- a/rotatingtext/src/main/java/com/sdsmdg/harjot/rotatingtext/RotatingTextWrapper.java
+++ b/rotatingtext/src/main/java/com/sdsmdg/harjot/rotatingtext/RotatingTextWrapper.java
@@ -86,9 +86,11 @@ public class RotatingTextWrapper extends RelativeLayout {
 
             if (array.length == 0) {
                 final RotatingTextSwitcher textSwitcher = new RotatingTextSwitcher(context);
+
                 switcherList.add(textSwitcher);
 
                 textSwitcher.setRotatable(rotatableList.get(0));
+
 
                 if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR1) {
                     textSwitcher.setId(Utils.generateViewId());
@@ -397,4 +399,6 @@ public class RotatingTextWrapper extends RelativeLayout {
     public List<RotatingTextSwitcher> getSwitcherList() {
         return switcherList;
     }
+
+    public Rotatable getRotatable() { return (rotatableList.get(0)); }
 }

--- a/rotatingtext/src/main/java/com/sdsmdg/harjot/rotatingtext/RotatingTextWrapper.java
+++ b/rotatingtext/src/main/java/com/sdsmdg/harjot/rotatingtext/RotatingTextWrapper.java
@@ -287,8 +287,8 @@ public class RotatingTextWrapper extends RelativeLayout {
         }
     }
 
-
-
+    
+  
 
     private void setChanges(RotatingTextSwitcher switcher, Rotatable toChange) {
         switcher.setText(toChange.getLargestWordWithSpace());
@@ -298,7 +298,7 @@ public class RotatingTextWrapper extends RelativeLayout {
             else reduceSize(changedSize / getSize());
         }
 
-
+   
     }
 
     private int availablePixels() {

--- a/rotatingtext/src/main/java/com/sdsmdg/harjot/rotatingtext/RotatingTextWrapper.java
+++ b/rotatingtext/src/main/java/com/sdsmdg/harjot/rotatingtext/RotatingTextWrapper.java
@@ -12,10 +12,8 @@ import android.util.TypedValue;
 import android.view.View;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
-
 import com.sdsmdg.harjot.rotatingtext.models.Rotatable;
 import com.sdsmdg.harjot.rotatingtext.utils.Utils;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -399,7 +397,4 @@ public class RotatingTextWrapper extends RelativeLayout {
     public List<RotatingTextSwitcher> getSwitcherList() {
         return switcherList;
     }
-
-
-
 }

--- a/rotatingtext/src/main/java/com/sdsmdg/harjot/rotatingtext/models/Rotatable.java
+++ b/rotatingtext/src/main/java/com/sdsmdg/harjot/rotatingtext/models/Rotatable.java
@@ -31,7 +31,7 @@ public class Rotatable {
     private boolean isCenter = false;
 
     private boolean isUpdated = false;
-    int val=1;
+
     private int FPS = 60;
 
     public Rotatable(int updateDuration, String... text) {
@@ -294,12 +294,4 @@ public class Rotatable {
     public void setFPS(int FPS) {
         this.FPS = FPS;
     }
-
-    public void setCycles(int val) {
-        this.val = val;
-    }
-    public int getCycles() {
-        return val;
-    }
-
 }

--- a/rotatingtext/src/main/java/com/sdsmdg/harjot/rotatingtext/models/Rotatable.java
+++ b/rotatingtext/src/main/java/com/sdsmdg/harjot/rotatingtext/models/Rotatable.java
@@ -155,7 +155,9 @@ public class Rotatable {
         }
     }
 
-    public int getUpdateDuration() { return updateDuration; }
+    public int getUpdateDuration() {
+        return updateDuration;
+    }
 
     public void setUpdateDuration(int updateDuration) {
         this.updateDuration = updateDuration;
@@ -173,9 +175,13 @@ public class Rotatable {
         return text[(currentWordNumber + 1) % text.length];
     }
 
-    public String getNextWord() { return text[getNextWordNumber()]; }
+    public String getNextWord() {
+        return text[getNextWordNumber()];
+    }
 
-    public String getCurrentWord() { return text[currentWordNumber]; }
+    public String getCurrentWord() {
+        return text[currentWordNumber];
+    }
 
     public String getPreviousWord() {
         if (currentWordNumber <= 0)
@@ -184,40 +190,60 @@ public class Rotatable {
             return text[currentWordNumber - 1];
     }
 
-    public float getSize() { return size; }
+    public float getSize() {
+        return size;
+    }
 
     public void setSize(float size) {
         this.size = size;
         setUpdated(true);
     }
 
-    public int getStrokeWidth() { return strokeWidth; }
+    public int getStrokeWidth() {
+        return strokeWidth;
+    }
 
-    public void setStrokeWidth(int strokeWidth) { this.strokeWidth = strokeWidth; }
+    public void setStrokeWidth(int strokeWidth) {
+        this.strokeWidth = strokeWidth;
+    }
 
-    public int getAnimationDuration() { return animationDuration; }
+    public int getAnimationDuration() {
+        return animationDuration;
+    }
 
     public void setAnimationDuration(int animationDuration) {
         this.animationDuration = animationDuration;
         setUpdated(true);
     }
 
-    public Path getPathIn() { return pathIn; }
+    public Path getPathIn() {
+        return pathIn;
+    }
 
-    public void setPathIn(Path pathIn) { this.pathIn = pathIn; }
+    public void setPathIn(Path pathIn) {
+        this.pathIn = pathIn;
+    }
 
-    public Path getPathOut() { return pathOut; }
+    public Path getPathOut() {
+        return pathOut;
+    }
 
-    public void setPathOut(Path pathOut) { this.pathOut = pathOut; }
+    public void setPathOut(Path pathOut) {
+        this.pathOut = pathOut;
+    }
 
-    public Interpolator getInterpolator() { return interpolator; }
+    public Interpolator getInterpolator() {
+        return interpolator;
+    }
 
     public void setInterpolator(Interpolator interpolator) {
         this.interpolator = interpolator;
         setUpdated(true);
     }
 
-    public Typeface getTypeface() { return typeface; }
+    public Typeface getTypeface() {
+        return typeface;
+    }
 
     public void setTypeface(Typeface typeface) {
         this.typeface = typeface;
@@ -266,19 +292,28 @@ public class Rotatable {
         return largest + " ";
     }
 
-    public boolean isCenter() { return isCenter; }
+    public boolean isCenter() {
+        return isCenter;
+    }
 
     public void setCenter(boolean center) {
         isCenter = center;
         setUpdated(true);
     }
 
-    public boolean isUpdated() { return isUpdated; }
+    public boolean isUpdated() {
+        return isUpdated;
+    }
 
-    public void setUpdated(boolean updated) { isUpdated = updated; }
+    public void setUpdated(boolean updated) {
+        isUpdated = updated;
+    }
 
-    public int getFPS() { return FPS; }
+    public int getFPS() {
+        return FPS;
+    }
 
-    public void setFPS(int FPS) { this.FPS = FPS; }
-
+    public void setFPS(int FPS) {
+        this.FPS = FPS;
+    }
 }

--- a/rotatingtext/src/main/java/com/sdsmdg/harjot/rotatingtext/models/Rotatable.java
+++ b/rotatingtext/src/main/java/com/sdsmdg/harjot/rotatingtext/models/Rotatable.java
@@ -84,17 +84,11 @@ public class Rotatable {
         return initialWord;
     }
 
-    public String[] getText() {
-        return text;
-    }
+    public String[] getText() { return text; }
 
-    public int getWordCount() {
-        return text.length;
-    }
+    public int getWordCount() { return text.length; }
 
-    public void setText(String... text) {
-        this.text = text;
-    }
+    public void setText(String... text) { this.text = text; }
 
     public String getTextAt(int index) {
         if (index >= text.length) {
@@ -161,9 +155,7 @@ public class Rotatable {
         }
     }
 
-    public int getUpdateDuration() {
-        return updateDuration;
-    }
+    public int getUpdateDuration() { return updateDuration; }
 
     public void setUpdateDuration(int updateDuration) {
         this.updateDuration = updateDuration;
@@ -181,13 +173,9 @@ public class Rotatable {
         return text[(currentWordNumber + 1) % text.length];
     }
 
-    public String getNextWord() {
-        return text[getNextWordNumber()];
-    }
+    public String getNextWord() { return text[getNextWordNumber()]; }
 
-    public String getCurrentWord() {
-        return text[currentWordNumber];
-    }
+    public String getCurrentWord() { return text[currentWordNumber]; }
 
     public String getPreviousWord() {
         if (currentWordNumber <= 0)
@@ -196,60 +184,40 @@ public class Rotatable {
             return text[currentWordNumber - 1];
     }
 
-    public float getSize() {
-        return size;
-    }
+    public float getSize() { return size; }
 
     public void setSize(float size) {
         this.size = size;
         setUpdated(true);
     }
 
-    public int getStrokeWidth() {
-        return strokeWidth;
-    }
+    public int getStrokeWidth() { return strokeWidth; }
 
-    public void setStrokeWidth(int strokeWidth) {
-        this.strokeWidth = strokeWidth;
-    }
+    public void setStrokeWidth(int strokeWidth) { this.strokeWidth = strokeWidth; }
 
-    public int getAnimationDuration() {
-        return animationDuration;
-    }
+    public int getAnimationDuration() { return animationDuration; }
 
     public void setAnimationDuration(int animationDuration) {
         this.animationDuration = animationDuration;
         setUpdated(true);
     }
 
-    public Path getPathIn() {
-        return pathIn;
-    }
+    public Path getPathIn() { return pathIn; }
 
-    public void setPathIn(Path pathIn) {
-        this.pathIn = pathIn;
-    }
+    public void setPathIn(Path pathIn) { this.pathIn = pathIn; }
 
-    public Path getPathOut() {
-        return pathOut;
-    }
+    public Path getPathOut() { return pathOut; }
 
-    public void setPathOut(Path pathOut) {
-        this.pathOut = pathOut;
-    }
+    public void setPathOut(Path pathOut) { this.pathOut = pathOut; }
 
-    public Interpolator getInterpolator() {
-        return interpolator;
-    }
+    public Interpolator getInterpolator() { return interpolator; }
 
     public void setInterpolator(Interpolator interpolator) {
         this.interpolator = interpolator;
         setUpdated(true);
     }
 
-    public Typeface getTypeface() {
-        return typeface;
-    }
+    public Typeface getTypeface() { return typeface; }
 
     public void setTypeface(Typeface typeface) {
         this.typeface = typeface;
@@ -298,28 +266,19 @@ public class Rotatable {
         return largest + " ";
     }
 
-    public boolean isCenter() {
-        return isCenter;
-    }
+    public boolean isCenter() { return isCenter; }
 
     public void setCenter(boolean center) {
         isCenter = center;
         setUpdated(true);
     }
 
-    public boolean isUpdated() {
-        return isUpdated;
-    }
+    public boolean isUpdated() { return isUpdated; }
 
-    public void setUpdated(boolean updated) {
-        isUpdated = updated;
-    }
+    public void setUpdated(boolean updated) { isUpdated = updated; }
 
-    public int getFPS() {
-        return FPS;
-    }
+    public int getFPS() { return FPS; }
 
-    public void setFPS(int FPS) {
-        this.FPS = FPS;
-    }
+    public void setFPS(int FPS) { this.FPS = FPS; }
+
 }

--- a/rotatingtext/src/main/java/com/sdsmdg/harjot/rotatingtext/models/Rotatable.java
+++ b/rotatingtext/src/main/java/com/sdsmdg/harjot/rotatingtext/models/Rotatable.java
@@ -31,7 +31,7 @@ public class Rotatable {
     private boolean isCenter = false;
 
     private boolean isUpdated = false;
-
+    int val=1;
     private int FPS = 60;
 
     public Rotatable(int updateDuration, String... text) {
@@ -293,6 +293,13 @@ public class Rotatable {
 
     public void setFPS(int FPS) {
         this.FPS = FPS;
+    }
+
+    public void setCycles(int val) {
+        this.val = val;
+    }
+    public int getCycles() {
+        return val;
     }
 
 }

--- a/rotatingtext/src/main/java/com/sdsmdg/harjot/rotatingtext/models/Rotatable.java
+++ b/rotatingtext/src/main/java/com/sdsmdg/harjot/rotatingtext/models/Rotatable.java
@@ -34,6 +34,10 @@ public class Rotatable {
 
     private int FPS = 60;
 
+    private int nCycles = 0, countCycles = 0;
+    private String initialWord = "";
+
+
     public Rotatable(int updateDuration, String... text) {
         this.updateDuration = updateDuration;
         this.text = text;
@@ -54,6 +58,30 @@ public class Rotatable {
     public void setColor(int color) {
         this.color = color;
         setUpdated(true);
+    }
+
+    public int countCycles(boolean bool) {
+        if(bool) {
+            countCycles = countCycles + 1;
+        }
+        return countCycles;
+    }
+
+    public void setCycles(int val) {
+        this.nCycles = val;
+        countCycles = 0;
+    }
+
+    public int getCycles() {
+        return nCycles;
+    }
+
+    public void setInitialWord(String initialWord) {
+        this.initialWord = initialWord;
+    }
+
+    public String getInitialWord() {
+        return initialWord;
     }
 
     public String[] getText() {

--- a/rotatingtext/src/main/java/com/sdsmdg/harjot/rotatingtext/models/Rotatable.java
+++ b/rotatingtext/src/main/java/com/sdsmdg/harjot/rotatingtext/models/Rotatable.java
@@ -84,11 +84,17 @@ public class Rotatable {
         return initialWord;
     }
 
-    public String[] getText() { return text; }
+    public String[] getText() {
+        return text;
+    }
 
-    public int getWordCount() { return text.length; }
+    public int getWordCount() {
+        return text.length;
+    }
 
-    public void setText(String... text) { this.text = text; }
+    public void setText(String... text) {
+        this.text = text;
+    }
 
     public String getTextAt(int index) {
         if (index >= text.length) {
@@ -316,4 +322,5 @@ public class Rotatable {
     public void setFPS(int FPS) {
         this.FPS = FPS;
     }
+
 }


### PR DESCRIPTION
 Fixes #7 - Rotations can be stopped after the no. of cycles user has specified.

I have added code mainly in RotatingTextSwitcher.java  to access the current word (I have considered the word at index 0 initially to be the first word of a cycle)and accordingly keep count of the no. of cycles .As soon as the specified no. of cycles are over the counter variables are reset to 0 and animation is paused. 